### PR TITLE
fix: Remove unknown arg from log call

### DIFF
--- a/kitops/cli/kit.py
+++ b/kitops/cli/kit.py
@@ -440,7 +440,7 @@ def _run(
         output = "% " + " ".join(command)
         if IS_A_TTY:
             output = f"{Color.CYAN.value}{output}{Color.RESET.value}"
-        LOG.info(output, flush=True)
+        LOG.info(output)
 
     # Because check=True is used, any non-zero exit status will raise a CalledProcessError.
     return subprocess.run(


### PR DESCRIPTION
## Fix log statement
The transition from print statements to logging broke the `pack_and_push_modelkit` method:
```
TypeError: Logger._log() got an unexpected keyword argument 'flush'
```
The `flush` keyword argument is supported by `print()`, but not by `info()`.
(I am using python 3.13.2)