### PR TITLE
Add titles to files without H1

### DIFF
--- a/docs/before-you-begin.md
+++ b/docs/before-you-begin.md
@@ -1,3 +1,6 @@
+---
+title: Before you begin with PyKitOps
+---
 ## Before You Begin
 
 This project was created using Python v3.12, but works with Python versions >= 3.10.

--- a/docs/reference/kit.md
+++ b/docs/reference/kit.md
@@ -1,3 +1,6 @@
+---
+title: Kit Commands
+---
 ## Kit Commands
 
 These functions provide programmatic access to the KitOps Command-Line Interface.

--- a/docs/reference/kitfile.md
+++ b/docs/reference/kitfile.md
@@ -1,3 +1,6 @@
+---
+title: Kitfile Class
+---
 ## `Kitfile` class
 
 You can import the `Kitfile` class from `kitops.modelkit.kitfile`:

--- a/docs/reference/manager.md
+++ b/docs/reference/manager.md
@@ -1,3 +1,6 @@
+---
+title: ModelKitManager Class
+---
 ## `ModelKitManager` class
 
 You can import the `ModelKitManager` class from `kitops.modelkit.manager`:

--- a/docs/reference/reference.md
+++ b/docs/reference/reference.md
@@ -1,3 +1,6 @@
+---
+title: ModelKitReference Class
+---
 ## `ModelKitReference` class
 
 You can import the `ModelKitReference` class from `kitops.modelkit.reference`:

--- a/docs/reference/user.md
+++ b/docs/reference/user.md
@@ -1,3 +1,6 @@
+---
+title: UserCredentials Class
+---
 ## `UserCredentials` class
 
 You can import the `UserCredentials` class from `kitops.modelkit.user`:


### PR DESCRIPTION
For the `llm.txt` generation, we need to have titles on all pages, the files in this PR are missing a title (H1 tag) so i added a title metadata.